### PR TITLE
Set package's repository

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "description": "Browserify transform for node-config (aka. config) library",
   "main": "index.js",
   "devDependencies": {},
+  "repository": "bluejamesbond/node-configify",
   "author": "Mathew Kurian",
   "license": "ISC"
 }


### PR DESCRIPTION
This is required in order for the GitHub link to show up in the npm page.
