### PR TITLE
link to absolute repo url so that npm links to github properly

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,10 @@
   "description": "Browserify transform for node-config (aka. config) library",
   "main": "index.js",
   "devDependencies": {},
-  "repository": "bluejamesbond/node-configify",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/bluejamesbond/node-configify.git"
+  },
   "author": "Mathew Kurian",
   "license": "ISC"
 }


### PR DESCRIPTION
if you go to npm now it's a bit hard to find this, adding the full url should make npm link to your github repo https://www.npmjs.com/package/config-browserify
